### PR TITLE
[Fixes #3] Use :current version of parser face

### DIFF
--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -40,7 +40,7 @@ module PuppetSyntax
 
     private
     def validate_manifest(file)
-      Puppet::Face[:parser, '0.0.1'].validate(file)
+      Puppet::Face[:parser, :current].validate(file)
     end
   end
 end


### PR DESCRIPTION
Rather than hard-coding a value. This will allow us to use a newer version
if Puppet core changes the default. Our tests will pick up any compat
issues.
