### PR TITLE
Test for future_parser on Puppet <= 3.2 

### DIFF
--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -74,11 +74,23 @@ describe PuppetSyntax::Manifests do
       }
 
       if Puppet::Util::Package.versioncmp(Puppet.version, '3.2') >= 0
-        it 'should pass with future option set to true on future manifest' do
-          files = fixture_manifests(['future_syntax.pp'])
-          res = subject.check(files)
+        context 'Puppet >= 3.2' do
+          it 'should pass with future option set to true on future manifest' do
+            files = fixture_manifests(['future_syntax.pp'])
+            res = subject.check(files)
 
-          res.should have(0).items
+            res.should have(0).items
+          end
+        end
+      else
+        context 'Puppet <= 3.2' do
+          it 'should return an error that the parser option is not supported' do
+            files = fixture_manifests(['future_syntax.pp'])
+            res = subject.check(files)
+
+            res.should have(1).items
+            res[0].should == "Attempt to assign a value to unknown configuration parameter :parser"
+          end
         end
       end
     end


### PR DESCRIPTION
This extends our coverage for the other side of the `if` condition on
`Puppet.version` and specifies what will happen if someone tries to use this
option on an older version of Puppet.

And add isolation for tests which change settings.
## 

This occurred to me over lunch.
/cc @hajee @gds-operations/owners 
