### PR TITLE
Removing the puppet dependency from the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 # Override gemspec for CI matrix builds.
-if ENV['PUPPET_VERSION']
-  gem 'puppet', ENV['PUPPET_VERSION']
-end
+puppet_version = ENV['PUPPET_VERSION'] || '>2.7.0'
+gem 'puppet', puppet_version

--- a/puppet-syntax.gemspec
+++ b/puppet-syntax.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Dan Carley"]
   spec.email         = ["dan.carley@gmail.com"]
   spec.description   = %q{Syntax checks for Puppet manifests and templates}
-  spec.summary       = spec.summary
-  spec.homepage      = ""
+  spec.summary       = %q{Syntax checks for Puppet manifests, templates, and Hiera YAML}
+  spec.homepage      = "https://github.com/gds-operations/puppet-syntax"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rake"
-  spec.add_dependency "puppet", ">= 2.7.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "< 2.99.0"


### PR DESCRIPTION
Not everyone uses puppet from a gem, which makes it hard to use e.g. for PE or for anyone installing from a package.
