### PR TITLE
TypeError and test

### DIFF
--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -18,6 +18,9 @@ module PuppetSyntax
         rescue NameError
           # This is normal because we don't have the variables that would
           # ordinarily be bound by the parent Puppet manifest.
+        rescue TypeError
+          # This is normal because we don't have the variables that would
+          # ordinarily be bound by the parent Puppet manifest.
         rescue SyntaxError => error
           errors << error
         end

--- a/spec/fixtures/test_module/templates/typeerror_shouldwin.erb
+++ b/spec/fixtures/test_module/templates/typeerror_shouldwin.erb
@@ -1,0 +1,2 @@
+#this is valid syntax
+<%= File.dirname(@the_path_of_the_file_you_first_thought_of) %>

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -52,4 +52,11 @@ describe PuppetSyntax::Templates do
     res[0].should match(/2: syntax error, unexpected/)
     res[1].should match(/2: warning: found = in conditional/)
   end
+
+  it 'should ignore a TypeError' do
+    files = fixture_templates('typeerror_shouldwin.erb')
+    res = subject.check(files)
+
+    res.should == []
+  end
 end


### PR DESCRIPTION
Consider:

<%= File.dirname(@configfile) %>

Previously this would fail for TypeError

This should pass ERB validation, which this patch fixes (i.e. the same thing passed through erb -P -x -T '-' deploy/1_0_5/modules/puppetagent/templates/puppet.conf.erb | ruby -c) wins
