### PR TITLE
Support syntax checking of hiera data in modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ When you are using a Puppet version greater then 3.2, you can select the future 
 
     PuppetSyntax.future_parser = true
 
+If you are using some form of hiera data inside your module, you can configure where the `syntax:hiera:yaml` task looks for data with:
+
+    PuppetSyntax.hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
 
 ## Installation
 

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -5,7 +5,7 @@ require "puppet-syntax/hiera"
 
 module PuppetSyntax
   class << self
-    attr_accessor :exclude_paths, :future_parser
+    attr_accessor :exclude_paths, :future_parser, :hieradata_paths
 
     def exclude_paths
       @exclude_paths || []
@@ -13,6 +13,10 @@ module PuppetSyntax
 
     def future_parser
       @future_parser || false
+    end
+
+    def hieradata_paths
+      @hieradata_paths || ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
     end
   end
 end

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -59,7 +59,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
         namespace :hiera do
           task :yaml do |t|
             $stderr.puts "---> #{t.name}"
-            files = FileList["data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
+            files = FileList.new(PuppetSyntax.hieradata_paths)
             files.reject! { |f| File.directory?(f) }
             files = files.exclude(*PuppetSyntax.exclude_paths)
 


### PR DESCRIPTION
We've started using ripienaar's puppet-module-data backend which looks for hiera data and a hiera.yaml in the `data` directory of a module. This PR adds `data/**/*.yaml` to the search path for the `hiera:yaml` task.
