### PR TITLE
Release version 1.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2014-08-07 Release 1.3.0
+- Add the ability to pass hieradata_paths array of globs to check
+- Check hieradata in modules ('**/data/**/*.yaml') by default
+
 2014-08-05 Release 1.2.3
 - Fix puppetlabs_spec_helper warning on Ruby 1.8
 

--- a/lib/puppet-syntax/version.rb
+++ b/lib/puppet-syntax/version.rb
@@ -1,3 +1,3 @@
 module PuppetSyntax
-  VERSION = "1.2.3"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Adds backwards-compatible functionality, hence minor version bump rather than patch version bump.
- Add the ability to pass hieradata_paths array of globs (f274a7b)
- Check hieradata in modules ('**/data/**/*.yaml') by default (11d7770)

/cc @danzilio as he might want to update his dependencies when published.
