### PR TITLE
Move gem_publisher require inside rake task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new('spec')
 
-require 'gem_publisher'
 task :publish_gem do
+  require 'gem_publisher'
   gem = GemPublisher.publish_if_updated('puppet-syntax.gemspec', :rubygems)
   puts "Published #{gem}" if gem
 end


### PR DESCRIPTION
gem_publisher does not support ruby 1.8.  This was causing the matrix
builds to fail in travis[1].  Moving this require inside the rake task
should prevent it being loaded until we actually try to publish the gem,
which in turn should allow the matrix builds to complete.

[1] https://travis-ci.org/gds-operations/puppet-syntax/builds/36201727
