### PR TITLE
lazy load the puppet and puppet/face as it creates issues on windows

### DIFF
--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -1,10 +1,9 @@
-require 'puppet'
-require 'puppet/face'
-
 module PuppetSyntax
   class Manifests
     def check(filelist)
       raise "Expected an array of files" unless filelist.is_a?(Array)
+      require 'puppet'
+      require 'puppet/face'
 
       errors = []
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'puppet-syntax'
+require 'puppet'
 
 def fixture_hiera(list)
   fixture_files(list, 'hiera')


### PR DESCRIPTION
When I use puppet-syntax in conjunction with puppet labs-spec-helper I am required to load puppet even though I don't actually use the puppet-syntax validation tool.  This is causing my windows systems that use puppet to load the open source Puppet which has additional dependencies of some win32 modules instead of using the PE puppet.

By lazy loading the puppet code we can make the loading of puppet an optional step. This occurs because the puppet labs-spec-helper has a hard requirement on puppet-syntax.

https://github.com/puppetlabs/puppetlabs_spec_helper/blob/master/lib/puppetlabs_spec_helper/rake_tasks.rb#L206

Additionally since I moved the loading of puppet I had to use a require in the spec_helper.rb code since puppet is being lazy loaded.
