### PR TITLE
Run tests against puppet 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.7.3"
   - PUPPET_VERSION=">= 0"
 matrix:
   allow_failures:


### PR DESCRIPTION
Puppet 3.7 [deprecates a number of language features](https://docs.puppetlabs.com/puppet/3.7/reference/deprecated_language.html) in preparation for the future parser to become the default in 4.0. To ensure that puppet-syntax is a usable tool for detecting use of these features, we should test against Puppet 3.7.

This relates to PR #28.
