### PR TITLE
Restrict paths to validate for manifests and templates

### DIFF
--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -31,7 +31,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
         desc 'Syntax check Puppet manifests'
         task :manifests do |t|
           $stderr.puts "---> #{t.name}"
-          files = FileList["**/*.pp"]
+          files = FileList["manifests/**/*.pp"]
           files.reject! { |f| File.directory?(f) }
           files = files.exclude(*PuppetSyntax.exclude_paths)
 
@@ -43,7 +43,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
         desc 'Syntax check Puppet templates'
         task :templates do |t|
           $stderr.puts "---> #{t.name}"
-          files = FileList["**/templates/**/*"]
+          files = FileList["templates/**/*"]
           files.reject! { |f| File.directory?(f) }
           files = files.exclude(*PuppetSyntax.exclude_paths)
 


### PR DESCRIPTION
The current code validates all `**/*.pp` manifests and all `**/templates/**/*` templates.

This means it also validates anything in `spec/fixtures`, as well as anything in `vendor/bundle` (for example).

These tasks should only validate local code, not dependencies or util libraries.
