### PR TITLE
[#31] Use rbenv in jenkins.sh because Psych bug

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eu
 
+# Avoid Psych bug in Ruby 1.9.3p0 on Ubuntu 12.04
+export RBENV_VERSION="1.9.3"
+
 rm -f Gemfile.lock
-bundle install --path "${HOME}/bundles/${JOB_NAME}"
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --shebang ruby
 bundle exec rake
 bundle exec rake publish_gem


### PR DESCRIPTION
Switch to using Ruby 1.9.3-p550 provided by rbenv instead of 1.9.3p0
provided by Ubuntu 12.04 when running Jenkins tests on our internal CI.

The previous version was causing test failures when handling YAML due to a
bug in Psych as described by Sam in gds-operations/vcloud-core@d6eaf27. I
don't think we need the trick to delete old shebangs because `--shebang`
appears to regenerate them all anyway.

```
1) PuppetSyntax::Hiera should return an error from invalid YAML
   Failure/Error: expect(res.first).to match(expected)
     expected "(/home/jenkins/workspace/puppet-syntax/spec/fixtures/hiera/hiera_bad.yaml): couldn't parse YAML at line 0 column 8" to match /scanning a directive at line 1 column 1/
     Diff:
     @@ -1,2 +1,2 @@
     -/scanning a directive at line 1 column 1/
     +"(/home/jenkins/workspace/puppet-syntax/spec/fixtures/hiera/hiera_bad.yaml): couldn't parse YAML at line 0 column 8"
   # ./spec/puppet-syntax/hiera_spec.rb:27:in `block (2 levels) in <top (required)>'
```

This was preventing new releases from being automatically tagged and pushed
to rubygems. Merging this will allow 1.4.0 to go out. It will tag two
commits later than the CHANGELOG entry, but both commits only relate to
testing environments.
