### PR TITLE
Adding Support for `app_management` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ If you are using some form of hiera data inside your module, you can configure w
 
     PuppetSyntax.hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
 
+If you are trying to validate the syntax of code written for application orchestration, you can enable the `app_management` setting:
+
+    PuppetSyntax.app_management = true
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -8,8 +8,9 @@ module PuppetSyntax
   @future_parser = false
   @hieradata_paths = ["**/data/**/*.*yaml", "hieradata/**/*.*yaml", "hiera*.*yaml"]
   @fail_on_deprecation_notices = true
+  @app_management = false
 
   class << self
-    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices, :epp_only
+    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices, :epp_only, :app_management
   end
 end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -59,6 +59,7 @@ module PuppetSyntax
     private
     def validate_manifest(file)
       Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet::PUPPETVERSION.to_i < 4
+      Puppet[:app_management] = true if PuppetSyntax.app_management and Puppet::PUPPETVERSION.to_f >= 4.3
       Puppet::Face[:parser, :current].validate(file)
     end
   end

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -54,6 +54,13 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
 'true'. The `future_parser setting will be ignored.
             EOS
           end
+          if Puppet::PUPPETVERSION.to_f < 4.3 and PuppetSyntax.app_management
+            $stderr.puts <<-EOS
+[WARNING] Puppet `app_managment` has been detected but the Puppet
+version is less then 4.3.  The `app_management` setting will be ignored.
+            EOS
+          end
+
           $stderr.puts "---> #{t.name}"
 
           c = PuppetSyntax::Manifests.new

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -56,7 +56,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
           end
           if Puppet::PUPPETVERSION.to_f < 4.3 and PuppetSyntax.app_management
             $stderr.puts <<-EOS
-[WARNING] Puppet `app_managment` has been detected but the Puppet
+[WARNING] Puppet `app_management` has been detected but the Puppet
 version is less then 4.3.  The `app_management` setting will be ignored.
             EOS
           end

--- a/spec/fixtures/test_module/manifests/test_app.pp
+++ b/spec/fixtures/test_module/manifests/test_app.pp
@@ -1,0 +1,3 @@
+application test_app {
+
+}

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -136,6 +136,46 @@ describe PuppetSyntax::Manifests do
     end
   end
 
+  describe 'app_management' do
+    context 'app_management = false (default)' do
+      it 'should fail to parse an application manifest' do
+
+        files = fixture_manifests(['test_app.pp'])
+        output,has_errors = subject.check(files)
+
+        expect(has_errors).to eq(true)
+        expect(output).to include(/error/)
+      end
+    end
+    context 'app_management = true' do
+      before(:each) {
+        PuppetSyntax.app_management = true
+      }
+      if Puppet::PUPPETVERSION.to_f >= 4.3
+        it 'should successfully parse an application manifest on Puppet >= 4.3.0' do
+          expect(PuppetSyntax.app_management).to eq(true)
+
+          files = fixture_manifests(['test_app.pp'])
+          output,has_errors = subject.check(files)
+
+          expect(output.size).to eq(0)
+          expect(has_errors).to eq(false)
+        end
+      else
+        it 'should fail to parse an application manifest on Puppet < 4.3.0' do
+          expect(PuppetSyntax.app_management).to eq(true)
+
+          files = fixture_manifests(['test_app.pp'])
+          output,has_errors = subject.check(files)
+
+          expect(output).to include(/error/)
+          expect(has_errors).to eq(true)
+        end
+      end
+    end
+  end
+
+
   describe 'future_parser' do
     context 'future_parser = false (default)' do
       if Puppet::Util::Package.versioncmp(Puppet.version, '4.0') < 0

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -137,6 +137,10 @@ describe PuppetSyntax::Manifests do
   end
 
   describe 'app_management' do
+    after do
+      PuppetSyntax.app_management = false
+    end
+
     context 'app_management = false (default)' do
       it 'should fail to parse an application manifest' do
 

--- a/spec/puppet-syntax/tasks/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax/tasks/puppet-syntax_spec.rb
@@ -18,7 +18,7 @@ describe 'PuppetSyntax rake tasks' do
   it 'should generate FileList of manifests relative to Rakefile' do
     list = PuppetSyntax::RakeTask.new.filelist_manifests
     expect(list).to include(known_pp)
-    expect(list.count).to eq 7
+    expect(list.count).to eq 8
   end
 
   it 'should generate FileList of templates relative to Rakefile' do

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe PuppetSyntax do
   after do
     PuppetSyntax.exclude_paths = []
+    PuppetSyntax.app_management = false
   end
 
   it 'should default exclude_paths to empty array' do

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -24,6 +24,11 @@ describe PuppetSyntax do
     expect(PuppetSyntax.future_parser).to eq(true)
   end
 
+  it 'should support app_management setting setting' do
+    PuppetSyntax.app_management = true
+    expect(PuppetSyntax.app_management).to eq(true)
+  end
+
   it 'should support a fail_on_deprecation_notices setting' do
     PuppetSyntax.fail_on_deprecation_notices = false
     expect(PuppetSyntax.fail_on_deprecation_notices).to eq(false)


### PR DESCRIPTION
Prior to this commit code written for application orchestration could
not be parsed correctly.  This commit adds support for this feature.