### PR TITLE
Only try to validate .erb or .epp files

### DIFF
--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -15,7 +15,7 @@ module PuppetSyntax
     end
 
     def filelist_templates
-      filelist("**/templates/**/*")
+      filelist(["**/templates/**/*.erb", "**/templates/**/*.epp"])
     end
 
     def filelist_hiera_yaml

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -14,7 +14,7 @@ module PuppetSyntax
       filelist.each do |file|
         if File.extname(file) == '.epp' or PuppetSyntax.epp_only
           errors.concat validate_epp(file)
-        else
+        elsif File.extname(file) == '.erb'
           errors.concat validate_erb(file)
         end
       end

--- a/spec/fixtures/test_module/templates/ignore.tpl
+++ b/spec/fixtures/test_module/templates/ignore.tpl
@@ -1,0 +1,3 @@
+This is plain text
+<% This is not valid Ruby %>
+This is also plain text

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -60,6 +60,13 @@ describe PuppetSyntax::Templates do
     expect(res).to match([])
   end
 
+  it 'should ignore files without .erb extension' do
+    files = fixture_templates('ignore.tpl')
+    res = subject.check(files)
+
+    expect(res).to match([])
+  end
+
   if Puppet::PUPPETVERSION.to_f < 3.7
     context 'on Puppet < 3.7' do
       it 'should throw an exception when parsing EPP files' do


### PR DESCRIPTION
puppet-syntax is trying to validate all files in any /template/ subdirectory, regardless of whether they're actually ERB files or not.

For example, in one of my projects I have some mako template files (like `files/monitoring/bin/scripts/templates/user_msg.tpl`). Mako templates are close enough to ERB to trigger the validator, but of course they fail to pass it. Those files shouldn't be checked at all, as they do not end in .erb nor are they in the top-level `templates/` directory.