### PR TITLE
Test Puppet 5 from master, don't set app_management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ rvm:
 env:
   - PUPPET_VERSION="~> 3.8.7"
   - PUPPET_VERSION="~> 4.8.0"
+  - PUPPET_VERSION="~> 4.9.0"
   - PUPPET_VERSION=">= 0"
+  - PUPPET_VERSION="git://github.com/puppetlabs/puppet.git#master"
 matrix:
   exclude:
     - env: PUPPET_VERSION="~> 3.8.7"
@@ -21,9 +23,16 @@ matrix:
       rvm: 2.3.3
     - env: PUPPET_VERSION="~> 3.8.7"
       rvm: 2.4.0
+    # 4.9 with Ruby 1.9.3 issues deprecation warnings
+    - env: PUPPET_VERSION="~> 4.9.0"
+      rvm: 1.9.3
+    - env: PUPPET_VERSION=">= 0"
+      rvm: 1.9.3
+    - env: PUPPET_VERSION="git://github.com/puppetlabs/puppet.git#master"
+      rvm: 1.9.3
   allow_failures:
     - env: PUPPET_VERSION=">= 0"
-
+    - env: PUPPET_VERSION="git://github.com/puppetlabs/puppet.git#master"
 deploy:
   provider: rubygems
   api_key:

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,24 @@
 source 'https://rubygems.org'
 
+# Find a location or specific version for a gem. place_or_version can be a
+# version, which is most often used. It can also be git, which is specified as
+# `git://somewhere.git#branch`. You can also use a file source location, which
+# is specified as `file://some/location/on/disk`.
+def location_for(place_or_version, fake_version = nil)
+  if place_or_version =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place_or_version =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place_or_version, { :require => false }]
+  end
+end
+
 # Specify your gem's dependencies in puppet-syntax.gemspec
 gemspec
 
 # Override gemspec for CI matrix builds.
-puppet_version = ENV['PUPPET_VERSION'] || '>2.7.0'
-gem 'puppet', puppet_version
+gem 'puppet', *location_for(ENV['PUPPET_VERSION'] || '>2.7.0')
 
 # older version required for ruby 1.9 compat, as it is pulled in as dependency of puppet, this has to be carried by the module
 gem 'json_pure', '<= 2.0.1'

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ If you are trying to validate the syntax of code written for application orchest
 
     PuppetSyntax.app_management = true
 
+`app_management` is supported on Puppet 4.3 or higher, defaulting to off. On Puppet 5, it is always enabled.
+
 Deprecation notices will cause a failure by default, you can override this functionality by setting:
 
     PuppetSyntax.fail_on_deprecation_notices = false

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -2,15 +2,22 @@ require "puppet-syntax/version"
 require "puppet-syntax/manifests"
 require "puppet-syntax/templates"
 require "puppet-syntax/hiera"
+require "puppet/version"
 
 module PuppetSyntax
   @exclude_paths = []
   @future_parser = false
   @hieradata_paths = ["**/data/**/*.*yaml", "hieradata/**/*.*yaml", "hiera*.*yaml"]
   @fail_on_deprecation_notices = true
-  @app_management = false
+  @app_management = Puppet::PUPPETVERSION.to_i >= 5 ? true : false
 
   class << self
-    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices, :epp_only, :app_management
+    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices, :epp_only
+    attr_reader :app_management
+
+    def app_management=(app_management)
+      raise 'app_management cannot be disabled on Puppet 5 or higher' if Puppet::PUPPETVERSION.to_i >= 5 && !app_management
+      @app_management = app_management
+    end
   end
 end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -59,7 +59,7 @@ module PuppetSyntax
     private
     def validate_manifest(file)
       Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet::PUPPETVERSION.to_i < 4
-      Puppet[:app_management] = true if PuppetSyntax.app_management and Puppet::PUPPETVERSION.to_f >= 4.3
+      Puppet[:app_management] = true if PuppetSyntax.app_management && (Puppet::PUPPETVERSION.to_f >= 4.3 && Puppet::PUPPETVERSION.to_i < 5)
       Puppet::Face[:parser, :current].validate(file)
     end
   end

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -138,10 +138,10 @@ describe PuppetSyntax::Manifests do
 
   describe 'app_management' do
     after do
-      PuppetSyntax.app_management = false
+      PuppetSyntax.app_management = false if Puppet::PUPPETVERSION.to_i < 5
     end
 
-    context 'app_management = false (default)' do
+    context 'app_management = false (default)', :if => (Puppet::PUPPETVERSION.to_i < 5) do
       it 'should fail to parse an application manifest' do
 
         files = fixture_manifests(['test_app.pp'])

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -30,7 +30,7 @@ describe PuppetSyntax::Manifests do
 
     if Puppet::PUPPETVERSION.to_i >= 4
       expect(output.size).to eq(3)
-      expect(output[2]).to match(/Found 2 errors. Giving up/)
+      expect(output[2]).to match(/2 errors. Giving up/)
       expect(has_errors).to eq(true)
     else
       expect(output.size).to eq(1)
@@ -76,7 +76,7 @@ describe PuppetSyntax::Manifests do
       expect(output.size).to eq(5)
       expect(output[0]).to match(/This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at \S*\/fail_error.pp:2:32$/)
       expect(output[1]).to match(/This Name has no effect. A value(-producing expression without other effect may only be placed last in a block\/sequence| was produced and then forgotten.*) at \S*\/fail_error.pp:2:3$/)
-      expect(output[2]).to match('Found 2 errors. Giving up')
+      expect(output[2]).to match('2 errors. Giving up')
       expect(output[3]).to match(/Unrecogni(s|z)ed escape sequence '\\\['/)
       expect(output[4]).to match(/Unrecogni(s|z)ed escape sequence '\\\]'/)
     else

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PuppetSyntax do
   after do
     PuppetSyntax.exclude_paths = []
-    PuppetSyntax.app_management = false
+    PuppetSyntax.app_management = false if Puppet::PUPPETVERSION.to_i < 5
   end
 
   it 'should default exclude_paths to empty array' do
@@ -28,6 +28,10 @@ describe PuppetSyntax do
   it 'should support app_management setting setting' do
     PuppetSyntax.app_management = true
     expect(PuppetSyntax.app_management).to eq(true)
+  end
+
+  it 'should raise error when app_management is disabled on 5.x', :if => (Puppet::PUPPETVERSION.to_i >= 5) do
+    expect { PuppetSyntax.app_management = false }.to raise_error(/app_management cannot be disabled on Puppet 5 or higher/)
   end
 
   it 'should support a fail_on_deprecation_notices setting' do


### PR DESCRIPTION
Fixes two failures under Puppet 5.0.0 from master.

master test on Travis CI will fail until the version number is incremented in https://github.com/puppetlabs/puppet/pull/5603.