### PR TITLE
Allow deeper checking of hiera keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ Deprecation notices will cause a failure by default, you can override this funct
 
     PuppetSyntax.fail_on_deprecation_notices = false
 
+Common mistakes in key names in Hiera files will be reported:
+
+- Leading :: in keys eg. `::notsotypical::warning2: true`
+- Single colon scope seperators eg. `:picky::warning5: true`
+- Invalid camel casing eg. `noCamelCase::warning3: true`
+- Use of hyphens eg. `no-hyphens::warning4: true`
+
+This can be enabled by setting
+
+    PuppetSyntax.check_hiera_keys = true
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -10,9 +10,15 @@ module PuppetSyntax
   @hieradata_paths = ["**/data/**/*.*yaml", "hieradata/**/*.*yaml", "hiera*.*yaml"]
   @fail_on_deprecation_notices = true
   @app_management = Puppet::PUPPETVERSION.to_i >= 5 ? true : false
+  @check_hiera_keys = false
 
   class << self
-    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices, :epp_only
+    attr_accessor :exclude_paths,
+                  :future_parser,
+                  :hieradata_paths,
+                  :fail_on_deprecation_notices,
+                  :epp_only,
+                  :check_hiera_keys
     attr_reader :app_management
 
     def app_management=(app_management)

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -7,7 +7,11 @@ require "puppet/version"
 module PuppetSyntax
   @exclude_paths = []
   @future_parser = false
-  @hieradata_paths = ["**/data/**/*.*yaml", "hieradata/**/*.*yaml", "hiera*.*yaml"]
+  @hieradata_paths = [
+    "**/data/**/*.*yaml",
+    "hieradata/**/*.*yaml",
+    "hiera*.*yaml"
+  ]
   @fail_on_deprecation_notices = true
   @app_management = Puppet::PUPPETVERSION.to_i >= 5 ? true : false
   @check_hiera_keys = false

--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -2,6 +2,24 @@ require 'yaml'
 
 module PuppetSyntax
   class Hiera
+
+    def check_hiera_key(key)
+      if key.is_a? Symbol
+        if key.to_s.start_with?(':')
+          return "Puppet automatic lookup will not use leading '::'"
+        elsif key !~ /^[a-z]+$/ # we allow Hiera's own configuration
+          return "Puppet automatic lookup will not look up symbols"
+        end
+      elsif key !~ /^[a-z][a-z0-9_]+(::[a-z][a-z0-9_]+)*$/
+        if key =~ /[^:]:[^:]/
+          # be extra helpful
+          return "Looks like a missing colon"
+        else
+          return "Not a valid Puppet variable name for automatic lookup"
+        end
+      end
+    end
+
     def check(filelist)
       raise "Expected an array of files" unless filelist.is_a?(Array)
 
@@ -9,11 +27,20 @@ module PuppetSyntax
 
       filelist.each do |hiera_file|
         begin
-          YAML.load_file(hiera_file)
+          yamldata = YAML.load_file(hiera_file)
         rescue Exception => error
           errors << "ERROR: Failed to parse #{hiera_file}: #{error}"
+          next
         end
-       end
+        if yamldata
+          yamldata.each do |k,v|
+            if PuppetSyntax.check_hiera_keys
+              key_msg = check_hiera_key(k)
+              errors << "WARNING: #{hiera_file}: Key :#{k}: #{key_msg}" if key_msg
+            end
+          end
+        end
+      end
 
       errors.map! { |e| e.to_s }
 

--- a/puppet-syntax.gemspec
+++ b/puppet-syntax.gemspec
@@ -21,5 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rake"
 
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "rb-readline"
   spec.add_development_dependency "gem_publisher", "~> 1.3"
 end

--- a/spec/fixtures/hiera/hiera_badkey.yaml
+++ b/spec/fixtures/hiera/hiera_badkey.yaml
@@ -1,0 +1,11 @@
+---
+this_is_ok: 0
+this_is_ok::too: 0
+th1s_is_ok::two3: 0
+:eventhis: 0
+
+typical:typo::warning1:   true
+::notsotypical::warning2: true
+noCamelCase::warning3:    true
+no-hyphens::warning4:     true
+:picky::warning5:         true


### PR DESCRIPTION
Resurrected from #57

* Add regexes for checking hiera key formats
* Enabled by flag 'check_hiera_keys' which is disabled by default as 
it's a breaking change
* Adds spec to catch issues
* Also move multiple entry arrays into separate lines to make cleaner
git history
* Add pry and rb-readline to the development dependancies to make 
development debugging easier