### PR TITLE
Use versioncmp to check Puppet version for 4.10.x compatibility

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -13,7 +13,7 @@ module PuppetSyntax
     "hiera*.*yaml"
   ]
   @fail_on_deprecation_notices = true
-  @app_management = Puppet::PUPPETVERSION.to_i >= 5 ? true : false
+  @app_management = Puppet.version.to_i >= 5 ? true : false
   @check_hiera_keys = false
 
   class << self
@@ -26,7 +26,7 @@ module PuppetSyntax
     attr_reader :app_management
 
     def app_management=(app_management)
-      raise 'app_management cannot be disabled on Puppet 5 or higher' if Puppet::PUPPETVERSION.to_i >= 5 && !app_management
+      raise 'app_management cannot be disabled on Puppet 5 or higher' if Puppet.version.to_i >= 5 && !app_management
       @app_management = app_management
     end
   end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -59,7 +59,7 @@ module PuppetSyntax
     private
     def validate_manifest(file)
       Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet::PUPPETVERSION.to_i < 4
-      Puppet[:app_management] = true if PuppetSyntax.app_management && (Puppet::PUPPETVERSION.to_f >= 4.3 && Puppet::PUPPETVERSION.to_i < 5)
+      Puppet[:app_management] = true if PuppetSyntax.app_management && (Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 && Puppet.version.to_i < 5)
       Puppet::Face[:parser, :current].validate(file)
     end
   end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -58,7 +58,7 @@ module PuppetSyntax
 
     private
     def validate_manifest(file)
-      Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet::PUPPETVERSION.to_i < 4
+      Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet.version.to_i < 4
       Puppet[:app_management] = true if PuppetSyntax.app_management && (Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 && Puppet.version.to_i < 5)
       Puppet::Face[:parser, :current].validate(file)
     end

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -48,7 +48,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
 
         desc 'Syntax check Puppet manifests'
         task :manifests do |t|
-          if Puppet::PUPPETVERSION.to_i >= 4 and PuppetSyntax.future_parser
+          if Puppet.version.to_i >= 4 and PuppetSyntax.future_parser
             $stderr.puts <<-EOS
 [INFO] Puppet 4 has been detected and `future_parser` has been set to
 'true'. The `future_parser setting will be ignored.

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -54,7 +54,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
 'true'. The `future_parser setting will be ignored.
             EOS
           end
-          if Puppet::PUPPETVERSION.to_f < 4.3 and PuppetSyntax.app_management
+          if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') < 0 and PuppetSyntax.app_management
             $stderr.puts <<-EOS
 [WARNING] Puppet `app_management` has been detected but the Puppet
 version is less then 4.3.  The `app_management` setting will be ignored.

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -27,7 +27,7 @@ module PuppetSyntax
     end
 
     def validate_epp(filename)
-      if Puppet::PUPPETVERSION.to_f < 3.7
+      if Puppet.version.to_f < 3.7
         raise "Cannot validate EPP without Puppet 4 or future parser (3.7+)"
       end
 

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -155,7 +155,7 @@ describe PuppetSyntax::Manifests do
       before(:each) {
         PuppetSyntax.app_management = true
       }
-      if Puppet::PUPPETVERSION.to_f >= 4.3
+      if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
         it 'should successfully parse an application manifest on Puppet >= 4.3.0' do
           expect(PuppetSyntax.app_management).to eq(true)
 

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -28,7 +28,7 @@ describe PuppetSyntax::Manifests do
     files = fixture_manifests('fail_error.pp')
     output, has_errors = subject.check(files)
 
-    if Puppet::PUPPETVERSION.to_i >= 4
+    if Puppet.version.to_i >= 4
       expect(output.size).to eq(3)
       expect(output[2]).to match(/2 errors. Giving up/)
       expect(has_errors).to eq(true)
@@ -72,7 +72,7 @@ describe PuppetSyntax::Manifests do
     output, has_errors = subject.check(files)
 
     expect(has_errors).to eq(true)
-    if Puppet::PUPPETVERSION.to_i >= 4
+    if Puppet.version.to_i >= 4
       expect(output.size).to eq(5)
       expect(output[0]).to match(/This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at \S*\/fail_error.pp:2:32$/)
       expect(output[1]).to match(/This Name has no effect. A value(-producing expression without other effect may only be placed last in a block\/sequence| was produced and then forgotten.*) at \S*\/fail_error.pp:2:3$/)
@@ -138,10 +138,10 @@ describe PuppetSyntax::Manifests do
 
   describe 'app_management' do
     after do
-      PuppetSyntax.app_management = false if Puppet::PUPPETVERSION.to_i < 5
+      PuppetSyntax.app_management = false if Puppet.version.to_i < 5
     end
 
-    context 'app_management = false (default)', :if => (Puppet::PUPPETVERSION.to_i < 5) do
+    context 'app_management = false (default)', :if => (Puppet.version.to_i < 5) do
       it 'should fail to parse an application manifest' do
 
         files = fixture_manifests(['test_app.pp'])
@@ -211,7 +211,7 @@ describe PuppetSyntax::Manifests do
         PuppetSyntax.future_parser = true
       }
 
-      if Puppet::Util::Package.versioncmp(Puppet.version, '3.2') >= 0 and Puppet::PUPPETVERSION.to_i < 4
+      if Puppet::Util::Package.versioncmp(Puppet.version, '3.2') >= 0 and Puppet.version.to_i < 4
         context 'Puppet >= 3.2 < 4' do
           it 'should pass with future option set to true on future manifest' do
             files = fixture_manifests(['future_syntax.pp'])

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -67,7 +67,7 @@ describe PuppetSyntax::Templates do
     expect(res).to match([])
   end
 
-  if Puppet::PUPPETVERSION.to_f < 3.7
+  if Puppet.version.to_f < 3.7
     context 'on Puppet < 3.7' do
       it 'should throw an exception when parsing EPP files' do
         file = fixture_templates('pass.epp')
@@ -87,7 +87,7 @@ describe PuppetSyntax::Templates do
     end
   end
 
-  if Puppet::PUPPETVERSION.to_f >= 3.7
+  if Puppet.version.to_f >= 3.7
     context 'on Puppet >= 3.7' do
       it 'should return nothing from a valid file' do
         files = fixture_templates('pass.epp')

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PuppetSyntax do
   after do
     PuppetSyntax.exclude_paths = []
-    PuppetSyntax.app_management = false if Puppet::PUPPETVERSION.to_i < 5
+    PuppetSyntax.app_management = false if Puppet.version.to_i < 5
   end
 
   it 'should default exclude_paths to empty array' do
@@ -30,7 +30,7 @@ describe PuppetSyntax do
     expect(PuppetSyntax.app_management).to eq(true)
   end
 
-  it 'should raise error when app_management is disabled on 5.x', :if => (Puppet::PUPPETVERSION.to_i >= 5) do
+  it 'should raise error when app_management is disabled on 5.x', :if => (Puppet.version.to_i >= 5) do
     expect { PuppetSyntax.app_management = false }.to raise_error(/app_management cannot be disabled on Puppet 5 or higher/)
   end
 


### PR DESCRIPTION
`Puppet.version.to_f` on Puppet 4.10.0 will evaluate to `4.1`, causing
test and behavioural changes when conditionals check that the version is
equal or greater than versions such as `4.3`.

Version comparisons that are vulnerable to this have been changed to use
Puppet's versioncmp implementation, while most others only check for
for major version boundaries which is safe.

---

Second commit replaces `Puppet::PUPPETVERSION` with the public `Puppet.version` API.