### PR TITLE
Ensure namespace scope is inherited

### DIFF
--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -33,7 +33,7 @@ module PuppetSyntax
 
       namespace :syntax do
         task :check_puppetlabs_spec_helper do
-          psh_present = Rake::Task[:syntax].actions.any? { |a|
+          psh_present = task(:syntax).actions.any? { |a|
             a.inspect.match(/puppetlabs_spec_helper\/rake_tasks\.rb:\d+/)
           }
 


### PR DESCRIPTION
If the tasks have their own namespace, ex:
```
...
namespace :puppet do
  require 'puppet-syntax/tasks/puppet-syntax'
end
...
```

the following error is triggered:
```
Don't know how to build task 'syntax' (see --tasks)
/Users/vlad/.rvm/gems/ruby-2.3.4/gems/puppet-syntax-2.4.0/lib/puppet-syntax/tasks/puppet-syntax.rb:36:in `block (2 levels) in initialize'
/Users/vlad/.rvm/gems/ruby-2.3.4/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/Users/vlad/.rvm/gems/ruby-2.3.4/bin/ruby_executable_hooks:15:in `eval'
/Users/vlad/.rvm/gems/ruby-2.3.4/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => test => puppet:test => puppet:syntax => puppet:syntax:check_puppetlabs_spec_helper
(See full trace by running task with --trace)
```

This PR replaces `Rake::Task[:syntax]` with `task(:syntax)`, thus the namespace scope is inherited.