### PR TITLE
Add appveyor config for Windows testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: ruby
 # Workaround https://github.com/bundler/bundler/issues/3558
 before_install: gem install bundler
+install: bundle install --jobs 4 --retry 2 --without development
 script: bundle exec rake
 rvm:
   - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,7 @@ gem 'puppet', *location_for(ENV['PUPPET_VERSION'] || '>2.7.0')
 
 # older version required for ruby 1.9 compat, as it is pulled in as dependency of puppet, this has to be carried by the module
 gem 'json_pure', '<= 2.0.1'
+
+group :test do
+  gem 'rspec'
+end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+build: off
+
+branches:
+  only:
+    - master
+
+# ruby versions under test
+environment:
+  matrix:
+    - RUBY_VERSION: 21
+      PUPPET_VERSION: "~> 3.8.7"
+    - RUBY_VERSION: 21
+      PUPPET_VERSION: "~> 4.8.0"
+    - RUBY_VERSION: 23-x64
+      PUPPET_VERSION: "~> 4.9.0"
+    - RUBY_VERSION: 23-x64
+      PUPPET_VERSION: "> 0"
+    - RUBY_VERSION: 23-x64
+      PUPPET_VERSION: "git://github.com/puppetlabs/puppet.git#master"
+
+matrix:
+  allow_failures:
+    - RUBY_VERSION: 23-x64
+      PUPPET_VERSION: "git://github.com/puppetlabs/puppet.git#master"
+      
+install:
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - SET LOG_SPEC_ORDER=true
+  - bundle install --jobs 4 --retry 2 --without development
+
+before_test:
+  - type Gemfile.lock
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake spec

--- a/puppet-syntax.gemspec
+++ b/puppet-syntax.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake"
 
-  spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rb-readline"
   spec.add_development_dependency "gem_publisher", "~> 1.3"


### PR DESCRIPTION
Add appveyor.yml config to allow Windows testing.

The config does not exactly reflect the travis config, because:
 - appveyor only supports a set list of ruby versions
 - appveyor requires matrix combinations to be listed explicitly