### PR TITLE
Fix error checking in template and Hiera validation tasks

### DIFF
--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -74,9 +74,9 @@ version is less then 4.3.  The `app_management` setting will be ignored.
           $stderr.puts "---> #{t.name}"
 
           c = PuppetSyntax::Templates.new
-          output, has_errors = c.check(filelist_templates)
-          $stdout.puts "#{output.join("\n")}\n" unless output.empty?
-          exit 1 if has_errors || ( output.any? && PuppetSyntax.fail_on_deprecation_notices )
+          errors = c.check(filelist_templates)
+          $stdout.puts "#{errors.join("\n")}\n" unless errors.empty?
+          exit 1 unless errors.empty?
         end
 
         desc 'Syntax check Hiera config files'
@@ -88,9 +88,9 @@ version is less then 4.3.  The `app_management` setting will be ignored.
           task :yaml do |t|
             $stderr.puts "---> #{t.name}"
             c = PuppetSyntax::Hiera.new
-            output, has_errors = c.check(filelist_hiera_yaml)
-            $stdout.puts "#{output.join("\n")}\n" unless output.empty?
-            exit 1 if has_errors || ( output.any? && PuppetSyntax.fail_on_deprecation_notices )
+            errors = c.check(filelist_hiera_yaml)
+            $stdout.puts "#{errors.join("\n")}\n" unless errors.empty?
+            exit 1 unless errors.empty?
           end
         end
       end


### PR DESCRIPTION
b36571a assumed that the `check` method for template and Hiera files
would return a boolean and lines of output, but the API is slightly
different between them and the manifest checks. This restores the
original check for `errors.empty?` instead.