### PR TITLE
Allow specifying file paths for manifests and templates too

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ To configure Puppet::Syntax, add any of the following settings to your `Rakefile
 
         PuppetSyntax.hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
 
+* To configure specific paths for the Puppet syntax checks or for the templates checks, specify `manifests_paths` or `templates_paths` respectively. This is useful if you want to check specific paths only.
+
+        PuppetSyntax.manifests_paths = ["**/environments/future/*.pp"]
+        PuppetSyntax.templates_paths = ["**/modules/**/templates/*.erb"]
+
 * To validate the syntax of code written for application orchestration, enable `app_management`:
 
         PuppetSyntax.app_management = true

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -12,6 +12,13 @@ module PuppetSyntax
     "hieradata/**/*.*{yaml,yml}",
     "hiera*.*{yaml,yml}"
   ]
+  @manifests_paths = [
+    '**/*.pp'
+  ]
+  @templates_paths = [
+    '**/templates/**/*.erb',
+    '**/templates/**/*.epp'
+  ]
   @fail_on_deprecation_notices = true
   @app_management = Puppet.version.to_i >= 5 ? true : false
   @check_hiera_keys = false
@@ -20,6 +27,8 @@ module PuppetSyntax
     attr_accessor :exclude_paths,
                   :future_parser,
                   :hieradata_paths,
+                  :manifests_paths,
+                  :templates_paths,
                   :fail_on_deprecation_notices,
                   :epp_only,
                   :check_hiera_keys

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -13,11 +13,11 @@ module PuppetSyntax
     end
 
     def filelist_manifests
-      filelist("**/*.pp")
+      filelist(PuppetSyntax.manifests_paths)
     end
 
     def filelist_templates
-      filelist(["**/templates/**/*.erb", "**/templates/**/*.epp"])
+      filelist(PuppetSyntax.templates_paths)
     end
 
     def filelist_hiera_yaml

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -44,4 +44,12 @@ describe PuppetSyntax do
     expect(PuppetSyntax.epp_only).to eq(true)
   end
 
+  it 'should support setting paths for manifests, templates and hiera' do
+    PuppetSyntax.hieradata_paths = []
+    expect(PuppetSyntax.hieradata_paths).to eq([])
+    PuppetSyntax.manifests_paths = ["**/environments/production/**/*.pp"]
+    expect(PuppetSyntax.manifests_paths).to eq(["**/environments/production/**/*.pp"])
+    PuppetSyntax.templates_paths = []
+    expect(PuppetSyntax.templates_paths).to eq([])
+  end
 end


### PR DESCRIPTION
This can be useful in various situations, like when setting up a task
for checking a specific environment only (where we might be using
e.g. the future parser, or not allowing deprecations, and so on), or
when using this as part of a CI pipeline, where you might want to check
only the changed files for syntax, to save processing time.

As I currently need to do both, I found this would be the cleanest way to do it.