### PR TITLE
check consistency of ENC blobs in eyaml data

### DIFF
--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -61,7 +61,8 @@ module PuppetSyntax
 
         # Base64#decode64 will silently ignore characters outside the alphabet,
         # so we check resulting length of binary data instead
-        if Base64.decode64(base64).length != base64.length * 3 / 4
+        pad_length = base64.gsub(/[^=]/, '').length
+        if Base64.decode64(base64).length != base64.length * 3/4 - pad_length
           return "has corrupt base64 data"
         end
       end

--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'base64'
 
 module PuppetSyntax
   class Hiera
@@ -16,6 +17,52 @@ module PuppetSyntax
           return "Looks like a missing colon"
         else
           return "Not a valid Puppet variable name for automatic lookup"
+        end
+      end
+    end
+
+    # Recurse through complex data structures.  Return on first error.
+    def check_eyaml_data(name, val)
+      error = nil
+      if val.is_a? String
+        err = check_eyaml_blob(val)
+        error = "Key #{name} #{err}" if err
+      elsif val.is_a? Array
+        val.each_with_index do |v, idx|
+          error = check_eyaml_data("#{name}[#{idx}]", v)
+          break if error
+        end
+      elsif val.is_a? Hash
+        val.each do |k,v|
+          error = check_eyaml_data("#{name}['#{k}']", v)
+          break if error
+        end
+      end
+      error
+    end
+
+    def check_eyaml_blob(val)
+      return unless val =~ /^ENC\[/
+
+      val.sub!('ENC[', '')
+      val.gsub!(/\s+/, '')
+      if val !~ /\]$/
+        return "has unterminated eyaml value"
+      else
+        val.sub!(/\]$/, '')
+        method, base64 = val.split(/,/)
+        if base64 == nil
+          base64 = method
+          method = 'PKCS7'
+        end
+
+        return "has unknown eyaml method #{method}" unless ['PKCS7','GPG'].include? method
+        return "has unpadded or truncated base64 data" unless base64.length % 4 == 0
+
+        # Base64#decode64 will silently ignore characters outside the alphabet,
+        # so we check resulting length of binary data instead
+        if Base64.decode64(base64).length != base64.length * 3 / 4
+          return "has corrupt base64 data"
         end
       end
     end
@@ -38,6 +85,8 @@ module PuppetSyntax
               key_msg = check_hiera_key(k)
               errors << "WARNING: #{hiera_file}: Key :#{k}: #{key_msg}" if key_msg
             end
+            eyaml_msg = check_eyaml_data(k, v)
+            errors << "WARNING: #{hiera_file}: #{eyaml_msg}" if eyaml_msg
           end
         end
       end

--- a/spec/fixtures/hiera/hiera_bad.eyaml
+++ b/spec/fixtures/hiera/hiera_bad.eyaml
@@ -1,7 +1,4 @@
 ---
-acme::good1: >
-   ENC[PKCS7,
-     aGVsbG8sIHdvcmxk]
 acme::warning1: ENC[unknown-method,aGVsbG8sIHdvcmxk]
 acme::warning2: ENC[PKCS7,aGVsbG8sIHdvcmxk
 acme::warning3: ENC[PKCS7,aGVsbG8sIHdvcmxk==]
@@ -20,3 +17,8 @@ acme::warning6:
       ENC[PKCS7,
           aGVs!!!!bG8sIHdvcmxk
       ]
+acme::good1: >
+   ENC[PKCS7,
+     aGVsbG8sIHdvcmxk]
+acme::good2: ENC[GPG,aGVsbG8sIHdvcmxkIQ==]
+acme::good3: ENC[GPG,aGVsbG8sIHdvcmxkISE=]

--- a/spec/fixtures/hiera/hiera_bad.eyaml
+++ b/spec/fixtures/hiera/hiera_bad.eyaml
@@ -1,0 +1,22 @@
+---
+acme::good1: >
+   ENC[PKCS7,
+     aGVsbG8sIHdvcmxk]
+acme::warning1: ENC[unknown-method,aGVsbG8sIHdvcmxk]
+acme::warning2: ENC[PKCS7,aGVsbG8sIHdvcmxk
+acme::warning3: ENC[PKCS7,aGVsbG8sIHdvcmxk==]
+acme::warning4: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk]
+acme::warning5:
+  key1: foo
+  key2: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk]
+acme::warning6:
+  hash_key:
+    - element1
+    - >
+      ENC[PKCS7,
+          aGVsbG8sIHdvcmxk
+      ]
+    - >
+      ENC[PKCS7,
+          aGVs!!!!bG8sIHdvcmxk
+      ]

--- a/spec/puppet-syntax/hiera_spec.rb
+++ b/spec/puppet-syntax/hiera_spec.rb
@@ -43,6 +43,23 @@ describe PuppetSyntax::Hiera do
       expect(res[4]).to match('Key :picky::warning5: Puppet automatic lookup will not look up symbols')
     end
 
+    it "should return warnings for bad eyaml values" do
+      hiera_yaml = 'hiera_bad.eyaml'
+      examples = 6
+      files = fixture_hiera(hiera_yaml)
+      res = subject.check(files)
+      (1..examples).each do |n|
+        expect(res).to include(/::warning#{n}/)
+      end
+      expect(res.size).to be == examples
+      expect(res[0]).to match('Key acme::warning1 has unknown eyaml method unknown-method')
+      expect(res[1]).to match('Key acme::warning2 has unterminated eyaml value')
+      expect(res[2]).to match('Key acme::warning3 has unpadded or truncated base64 data')
+      expect(res[3]).to match('Key acme::warning4 has corrupt base64 data')
+      expect(res[4]).to match('Key acme::warning5\[\'key2\'\] has corrupt base64 data')
+      expect(res[5]).to match('Key acme::warning6\[\'hash_key\'\]\[2\] has corrupt base64 data')
+    end
+
     it "should handle empty files" do
       hiera_yaml = 'hiera_key_empty.yaml'
       files = fixture_hiera(hiera_yaml)


### PR DESCRIPTION
Revisiting the patch set for issue #56 , this is the code which checks the consistency of encoded blobs.  This time including tests, but without a switch to turn it on or off (it seems unnecessary to me).
