### PR TITLE
Add support for Puppet Plans

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -1,5 +1,6 @@
 require "puppet-syntax/version"
 require "puppet-syntax/manifests"
+require "puppet-syntax/plans"
 require "puppet-syntax/templates"
 require "puppet-syntax/hiera"
 require "puppet/version"

--- a/lib/puppet-syntax/plans.rb
+++ b/lib/puppet-syntax/plans.rb
@@ -1,0 +1,11 @@
+require_relative 'manifests'
+
+module PuppetSyntax
+  class Plans < Manifests
+    private
+    def validate_manifest(file)
+      Puppet[:tasks] = true
+      Puppet::Face[:parser, :current].validate(file)
+    end
+  end
+end

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -13,7 +13,11 @@ module PuppetSyntax
     end
 
     def filelist_manifests
-      filelist("**/*.pp")
+      filelist("**/*.pp").exclude('plans/**/*')
+    end
+
+    def filelist_plans
+      filelist("plans/**/*.pp")
     end
 
     def filelist_templates
@@ -29,6 +33,7 @@ module PuppetSyntax
       task :syntax => [
         'syntax:check_puppetlabs_spec_helper',
         'syntax:manifests',
+        'syntax:plans',
         'syntax:templates',
         'syntax:hiera',
       ]
@@ -67,6 +72,16 @@ version is less then 4.3.  The `app_management` setting will be ignored.
 
           c = PuppetSyntax::Manifests.new
           output, has_errors = c.check(filelist_manifests)
+          $stdout.puts "#{output.join("\n")}\n" unless output.empty?
+          exit 1 if has_errors || ( output.any? && PuppetSyntax.fail_on_deprecation_notices )
+        end
+
+        desc 'Syntax check Puppet Plans'
+        task :plans do |t|
+          $stderr.puts "---> #{t.name}"
+
+          c = PuppetSyntax::Plans.new
+          output, has_errors = c.check(filelist_plans)
           $stdout.puts "#{output.join("\n")}\n" unless output.empty?
           exit 1 if has_errors || ( output.any? && PuppetSyntax.fail_on_deprecation_notices )
         end


### PR DESCRIPTION
Use the `tasks` mode of the Puppet parser to syntax check plans in the `plans/` directory of a module. Fixes #95.