### PR TITLE
add support for validating puppet plans (fixes #95, fixes #96)

### DIFF
--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -64,7 +64,7 @@ module PuppetSyntax
     def validate_manifest(file)
       Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet.version.to_i < 4
       Puppet[:app_management] = true if PuppetSyntax.app_management && (Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 && Puppet.version.to_i < 5)
-      Puppet[:tasks] = true if Puppet.version.to_i >= 6 and file.match(/.*plans\/.*\.pp$/)
+      Puppet[:tasks] = true if Puppet::Util::Package.versioncmp(Puppet.version, '5.4.0') >= 0 and file.match(/.*plans\/.*\.pp$/)
       Puppet::Face[:parser, :current].validate(file)
     end
   end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -64,6 +64,7 @@ module PuppetSyntax
     def validate_manifest(file)
       Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet.version.to_i < 4
       Puppet[:app_management] = true if PuppetSyntax.app_management && (Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 && Puppet.version.to_i < 5)
+      Puppet[:tasks] = true if Puppet.version.to_i >= 6 and file.match(/.*plans\/.*\.pp$/)
       Puppet::Face[:parser, :current].validate(file)
     end
   end


### PR DESCRIPTION
enables the `:tasks` switch if the path matches regular expression and the puppet version is >= 6.x.