### PR TITLE
Allow .yml as an extension for YAML files.

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -8,9 +8,9 @@ module PuppetSyntax
   @exclude_paths = []
   @future_parser = false
   @hieradata_paths = [
-    "**/data/**/*.*yaml",
-    "hieradata/**/*.*yaml",
-    "hiera*.*yaml"
+    "**/data/**/*.*{yaml,yml}",
+    "hieradata/**/*.*{yaml,yml}",
+    "hiera*.*{yaml,yml}"
   ]
   @fail_on_deprecation_notices = true
   @app_management = Puppet.version.to_i >= 5 ? true : false


### PR DESCRIPTION
Without this patch, only files ending in .yaml will be checked. This
allows files to also end with .yml.

Fixes #98