### PR TITLE
search manifests in manifests directory

### DIFF
--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -13,7 +13,7 @@ module PuppetSyntax
     end
 
     def filelist_manifests
-      filelist("**/*.pp")
+      filelist("**/manifests/**/*.pp")
     end
 
     def filelist_templates


### PR DESCRIPTION
The syntax check searches for all `.pp` files in the modules, which includes
.pp `files` in the spec tests of the modules like in `spec/type_aliases`. This can lead to errors like:
```
bundle exec rake syntax 
---> syntax:manifests
Attempt to redefine entity 'http://puppet.com/2016.1/runtime/type/XXX'. Originally set at file:///builds/XXX/manifests/network.pp?line=24&pos=1.
```