### PR TITLE
Revert "search manifests in manifests directory"

### DIFF
--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -13,7 +13,7 @@ module PuppetSyntax
     end
 
     def filelist_manifests
-      filelist("**/manifests/**/*.pp")
+      filelist("**/*.pp")
     end
 
     def filelist_templates


### PR DESCRIPTION
Reverts voxpupuli/puppet-syntax#100

From slack...
> @Daneel Noooooooooooo oO This broke our usage of puppet-syntax. We're using a mono repo and therefore require the use of `filelist("**/*.pp")`