### PR TITLE
Support puppet 6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - PUPPET_VERSION="~> 5.5.10"
   - PUPPET_VERSION="~> 6.1.0"
   - PUPPET_VERSION="~> 6.2.0"
+  - PUPPET_VERSION="~> 6.5.0"
   - PUPPET_VERSION=">= 0"
   - PUPPET_VERSION="git://github.com/puppetlabs/puppet.git#master"
 matrix:

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -21,9 +21,13 @@ module PuppetSyntax
       filelist.each do |puppet_file|
         Puppet::Test::TestHelper.before_each_test
         begin
-          validate_manifest(puppet_file)
+          error = validate_manifest(puppet_file)
+          if error.is_a?(Hash) # Puppet 6.5.0 onwards
+            output << error.values.first unless error.empty?
+          end
         rescue SystemExit
           # Disregard exit(1) from face.
+          # This is how puppet < 6.5.0 `validate_manifest` worked.
         rescue => error
           output << error
         ensure


### PR DESCRIPTION
Longer term, it'd be better to use a public interface, but for now, code
for the changes to the private `validate_manifest` method made in
https://github.com/puppetlabs/puppet/pull/6909

See https://tickets.puppetlabs.com/browse/PUP-8984