### PR TITLE
fix broken unit tests

### DIFF
--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -34,7 +34,7 @@ describe PuppetSyntax::Templates do
     res = subject.check(files)
 
     expect(res.size).to eq(1)
-    expect(res[0]).to match(/2: warning: found = in conditional/)
+    expect(res[0]).to match(/2: warning: found.*=.* in conditional/)
   end
 
   it 'should read more than one valid file' do
@@ -50,7 +50,7 @@ describe PuppetSyntax::Templates do
 
     expect(res.size).to eq(2)
     expect(res[0]).to match(/2: syntax error, unexpected/)
-    expect(res[1]).to match(/2: warning: found = in conditional/)
+    expect(res[1]).to match(/2: warning: found.*=.* in conditional/)
   end
 
   it 'should ignore a TypeError' do


### PR DESCRIPTION
Failures on master before this fix:
```
Failures:

  1) PuppetSyntax::Templates should continue after finding an error in the first file
     Failure/Error: expect(res[1]).to match(/2: warning: found = in conditional/)
     
       expected "/home/bastelfreak/puppet-syntax/spec/fixtures/test_module/templates/fail_warning.erb:2: warning: found `= literal' in conditional, should be ==\n" to match /2: warning: found = in conditional/
       Diff:
       @@ -1,2 +1,2 @@
       -/2: warning: found = in conditional/
       +/home/bastelfreak/puppet-syntax/spec/fixtures/test_module/templates/fail_warning.erb:2: warning: found `= literal' in conditional, should be ==
       
     # ./spec/puppet-syntax/templates_spec.rb:53:in `block (2 levels) in <top (required)>'

```