### PR TITLE
Add `puppet` gem as runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,8 @@ end
 gemspec
 
 # Override gemspec for CI matrix builds.
-gem 'puppet', *location_for(ENV['PUPPET_VERSION'] || '>2.7.0')
+# But only if the environment variable is set
+gem 'puppet', *location_for(ENV['PUPPET_VERSION'] || '>= 5') if ENV['PUPPET_VERSION']
 
 # older version required for ruby 1.9 compat, as it is pulled in as dependency of puppet, this has to be carried by the module
 gem 'json_pure', '<= 2.0.1'

--- a/puppet-syntax.gemspec
+++ b/puppet-syntax.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rake"
+  spec.add_dependency "puppet", ">= 5"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rb-readline"


### PR DESCRIPTION
The gem is required in: https://github.com/bastelfreak/puppet-syntax/blob/55ea82ff7ed597f89a7507f8d6c9774b2bdb563c/lib/puppet-syntax/templates.rb#L2