### PR TITLE
Avoid failure on schedule metaparameter warning

### DIFF
--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -41,9 +41,9 @@ module PuppetSyntax
         e =~ /^You cannot collect( exported resources)? without storeconfigs being set/
       }
 
-      # tag parameter in class raise warnings notice in output that prevent from succeed
+      # tag and schedule parameters in class raise warnings notice in output that prevent from succeed
       output.reject! { |e|
-        e =~ /^tag is a metaparam; this value will inherit to all contained resources in the /
+        e =~ /^(tag|schedule) is a metaparam; this value will inherit to all contained resources in the /
       }
 
       deprecations = output.select { |e|

--- a/spec/fixtures/test_module/manifests/schedule_notice.pp
+++ b/spec/fixtures/test_module/manifests/schedule_notice.pp
@@ -1,0 +1,5 @@
+class schedule_parameter_test ($schedule=undef){
+  notify { 'schedule_should pass':
+    message => 'with flying colours',
+  }
+}

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -24,6 +24,14 @@ describe PuppetSyntax::Manifests do
     expect(has_errors).to eq(false)
   end
 
+  it 'should return nothing from a valid file with a class using schedule parameter' do
+    files = fixture_manifests('schedule_notice.pp')
+    output, has_errors = subject.check(files)
+
+    expect(output).to eq([])
+    expect(has_errors).to eq(false)
+  end
+
   it 'should return an error from an invalid file' do
     files = fixture_manifests('fail_error.pp')
     output, has_errors = subject.check(files)

--- a/spec/puppet-syntax/tasks/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax/tasks/puppet-syntax_spec.rb
@@ -18,7 +18,7 @@ describe 'PuppetSyntax rake tasks' do
   it 'should generate FileList of manifests relative to Rakefile' do
     list = PuppetSyntax::RakeTask.new.filelist_manifests
     expect(list).to include(known_pp)
-    expect(list.count).to eq 8
+    expect(list.count).to eq 9
   end
 
   it 'should generate FileList of templates relative to Rakefile' do


### PR DESCRIPTION
Syntax checking was failing (exit code 1) when puppet raises a the following warning
```
schedule is a metaparam; this value will inherit to all contained resources in the
```
Applied the same approach as `tag`.