### PR TITLE
support multiple encoded blocks

### DIFF
--- a/spec/fixtures/hiera/hiera_bad.eyaml
+++ b/spec/fixtures/hiera/hiera_bad.eyaml
@@ -1,11 +1,11 @@
 ---
-acme::warning1: ENC[unknown-method,aGVsbG8sIHdvcmxk]
-acme::warning2: ENC[PKCS7,aGVsbG8sIHdvcmxk
-acme::warning3: ENC[PKCS7,aGVsbG8sIHdvcmxk==]
-acme::warning4: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk]
+acme::warning1: ENC[unknown-method,aGVsbG8sIHdvcmxk] # unknown method
+acme::warning2: ENC[PKCS7,aGV&&&sbG8sIHdvcmxk] # unpadded or truncated base64 data
+acme::warning3: ENC[PKCS7,aGVsbG8sIHdvcmxk==] # unpadded or truncated base64 data
+acme::warning4: ENC[PKCS7,aGVsbG8sf&IHdvcmxk==] # corrupt base64 data
 acme::warning5:
   key1: foo
-  key2: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk]
+  key2: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk] # corrupt base64 data
 acme::warning6:
   hash_key:
     - element1
@@ -17,8 +17,5 @@ acme::warning6:
       ENC[PKCS7,
           aGVs!!!!bG8sIHdvcmxk
       ]
-acme::good1: >
-   ENC[PKCS7,
-     aGVsbG8sIHdvcmxk]
-acme::good2: ENC[GPG,aGVsbG8sIHdvcmxkIQ==]
-acme::good3: ENC[GPG,aGVsbG8sIHdvcmxkISE=]
+    # corrupt base64 data
+acme::warning7: ENC[KMSaGVsbG8sIdGHdvcmxk==] # has invalid eyaml encoded format

--- a/spec/fixtures/hiera/hiera_good.eyaml
+++ b/spec/fixtures/hiera/hiera_good.eyaml
@@ -1,0 +1,9 @@
+---
+acme::good1: ENC[KMS,aGVsbG8sIdGHdvcmxk==]
+acme::good2: ENC[PKCS7,aGVsbG8sf3IHdvcmxk==]
+acme::good3: ENC[KMS,aGVsbG8sIdGHdvcmxk==]ENC[KMS,aGVsbG8sIdGHdvcmxk==]
+acme::good4: >
+   ENC[PKCS7,
+     aGVsbG8sIHdvcmxk]
+acme::good5: ENC[GPG,aGVsbG8sIHdvcmxkIQ==]
+acme::good6: ENC[GPG,aGVsbG8sIHdvcmxkISE=]

--- a/spec/puppet-syntax/hiera_spec.rb
+++ b/spec/puppet-syntax/hiera_spec.rb
@@ -13,6 +13,13 @@ describe PuppetSyntax::Hiera do
     expect(res).to be == []
   end
 
+  it "should return nothing from valid EYAML" do
+    files = fixture_hiera('hiera_good.eyaml')
+    res = subject.check(files)
+    expect(res).to be == []
+  end
+
+
   it "should return an error from invalid YAML" do
     hiera_yaml = RUBY_VERSION =~ /1.8/ ? 'hiera_bad_18.yaml' : 'hiera_bad.yaml'
     files = fixture_hiera(hiera_yaml)
@@ -45,7 +52,7 @@ describe PuppetSyntax::Hiera do
 
     it "should return warnings for bad eyaml values" do
       hiera_yaml = 'hiera_bad.eyaml'
-      examples = 6
+      examples = 7
       files = fixture_hiera(hiera_yaml)
       res = subject.check(files)
       (1..examples).each do |n|
@@ -53,11 +60,12 @@ describe PuppetSyntax::Hiera do
       end
       expect(res.size).to be == examples
       expect(res[0]).to match('Key acme::warning1 has unknown eyaml method unknown-method')
-      expect(res[1]).to match('Key acme::warning2 has unterminated eyaml value')
+      expect(res[1]).to match('Key acme::warning2 has unpadded or truncated base64 data')
       expect(res[2]).to match('Key acme::warning3 has unpadded or truncated base64 data')
       expect(res[3]).to match('Key acme::warning4 has corrupt base64 data')
       expect(res[4]).to match('Key acme::warning5\[\'key2\'\] has corrupt base64 data')
       expect(res[5]).to match('Key acme::warning6\[\'hash_key\'\]\[2\] has corrupt base64 data')
+      expect(res[6]).to match('Key acme::warning7 has invalid eyaml encoded format')
     end
 
     it "should handle empty files" do


### PR DESCRIPTION
With KMS you have to split materials you wish to encode into 4096 blocks.
hiera-eyaml supports this but puppet-syntax thinks it's a problem.

```
$ eyaml encrypt -s 'hello '
Ignoring nio4r-2.5.4 because its extensions are not built.  Try: gem pristine nio4r --version 2.5.4
string: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAkSEgwSCvKHy2fDezZgywZVn4ysNkCnQddnbIBf207lzIpZ5QmDW1BYwFR5VrM7YcEgAcFW8QdmWJSdu9u9X2RMmRK5yv0YCWZXb4j1HqH8WqKHQGrvmDcoLhFQfuXr+NnTFkYab8ZXsW0YNtOqWKBQOI9xgjuwaQ/IvV9EcukhBlrXfAF/w3REA9NhMfwsRHKG/2voBcgogOLKOBC04J99xRg1gCcQxuIGpcM5YJ2rVySGiXRiM/TQl2Rct+Qm0XsZwP26V8XKPVgwQfkPkmaTcczujTW6DOnkIfH1bIh/YF+MYpsiD77UGTJIN/PoSyGtUtMC/I007ViWZZUHb+xzA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBImQOqKmc2Z/gRoWGRUQydgBD3Az8yo5t02FK7gcvZ6wya]

$ eyaml encrypt -s 'world'
Ignoring nio4r-2.5.4 because its extensions are not built.  Try: gem pristine nio4r --version 2.5.4
string: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAH8m/BE3dS8oYWirjAkGYkciH1+nvCG41+rowvOIJnCES2u36m3LcIBg3+B7V6PdeHWCkdheYodinIwNYWhJbDwgf9Em3z8J9vPh8FS0l9/jabKtbGJA4CWxsgiGtDqJE1oqUfOFaKf5JhjZdWLAywyimMiT8VfGdEmIkWMg6u6fgxOmlslN5lSKAL0Z2yTVya3vfJVq3RHVFQRJ50xQSVWGnhvOu/2p8oMmkbDzg/LxP2kR7akkTbBToAeyYzRgiQExKEG0FuJ97bs/1hNKpaaz1Ttw0zoVHN6ZJHOfyh1ykArxOzhK1iaptrM8iZ8ZxVkUUX54ac40Mg1R7GyX1+TA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBXrUVOjg8m5zQyuBNLF/nGgBDVXfrOsUFUXcmJhLTvyg28]

$ eyaml decrypt -s ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAkSEgwSCvKHy2fDezZgywZVn4ysNkCnQddnbIBf207lzIpZ5QmDW1BYwFR5VrM7YcEgAcFW8QdmWJSdu9u9X2RMmRK5yv0YCWZXb4j1HqH8WqKHQGrvmDcoLhFQfuXr+NnTFkYab8ZXsW0YNtOqWKBQOI9xgjuwaQ/IvV9EcukhBlrXfAF/w3REA9NhMfwsRHKG/2voBcgogOLKOBC04J99xRg1gCcQxuIGpcM5YJ2rVySGiXRiM/TQl2Rct+Qm0XsZwP26V8XKPVgwQfkPkmaTcczujTW6DOnkIfH1bIh/YF+MYpsiD77UGTJIN/PoSyGtUtMC/I007ViWZZUHb+xzA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBImQOqKmc2Z/gRoWGRUQydgBD3Az8yo5t02FK7gcvZ6wya]ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAH8m/BE3dS8oYWirjAkGYkciH1+nvCG41+rowvOIJnCES2u36m3LcIBg3+B7V6PdeHWCkdheYodinIwNYWhJbDwgf9Em3z8J9vPh8FS0l9/jabKtbGJA4CWxsgiGtDqJE1oqUfOFaKf5JhjZdWLAywyimMiT8VfGdEmIkWMg6u6fgxOmlslN5lSKAL0Z2yTVya3vfJVq3RHVFQRJ50xQSVWGnhvOu/2p8oMmkbDzg/LxP2kR7akkTbBToAeyYzRgiQExKEG0FuJ97bs/1hNKpaaz1Ttw0zoVHN6ZJHOfyh1ykArxOzhK1iaptrM8iZ8ZxVkUUX54ac40Mg1R7GyX1+TA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBXrUVOjg8m5zQyuBNLF/nGgBDVXfrOsUFUXcmJhLTvyg28]
Ignoring nio4r-2.5.4 because its extensions are not built.  Try: gem pristine nio4r --version 2.5.4
hello world
```

I've changed the behavior of the check_eyaml_blob code and added some tests.