### PR TITLE
disable vpt for this repo

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,3 @@
+---
+vpt:
+  enabled: false


### PR DESCRIPTION
Hi maintainers,

In [vox-pupuli-tasks](https://github.com/voxpupuli/vox-pupuli-tasks/issues/324) we have disabled this repository manually. 

Since we now support dynamic configuration we would like to get rid of our manual list and disable vpt for this repository via the `.sync.yml` file.

For more details see [the related issue](https://github.com/voxpupuli/vox-pupuli-tasks/issues/324), [the readme](https://github.com/voxpupuli/vox-pupuli-tasks#configure-your-module-repo) or [the implementation issue](https://github.com/voxpupuli/vox-pupuli-tasks/issues/304)