### PR TITLE
Update ERB handling

### DIFF
--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -69,7 +69,7 @@ module PuppetSyntax
       result = { warnings: [], errors: [] }
 
       begin
-        erb = ERB.new(File.read(filename), nil, '-')
+        erb = ERB.new(File.read(filename), trim_mode: '-')
         erb.filename = filename
         erb.result
       rescue NameError => error


### PR DESCRIPTION
This resolves the deprecation warnings I'm seeing with puppet-syntax:

```
WARNINGS:
/Users/akerl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppet-syntax-3.1.0/lib/puppet-syntax/templates.rb:72: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/akerl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppet-syntax-3.1.0/lib/puppet-syntax/templates.rb:72: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/Users/akerl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppet-syntax-3.1.0/lib/puppet-syntax/templates.rb:72: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/akerl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppet-syntax-3.1.0/lib/puppet-syntax/templates.rb:72: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/Users/akerl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppet-syntax-3.1.0/lib/puppet-syntax/templates.rb:72: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/akerl/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppet-syntax-3.1.0/lib/puppet-syntax/templates.rb:72: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```