### PR TITLE
Lazy load required classes

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -1,10 +1,10 @@
 require "puppet-syntax/version"
-require "puppet-syntax/manifests"
-require "puppet-syntax/templates"
-require "puppet-syntax/hiera"
-require "puppet/version"
 
 module PuppetSyntax
+  autoload :Hiera, 'puppet-syntax/hiera'
+  autoload :Manifests, 'puppet-syntax/manifests'
+  autoload :Templates, 'puppet-syntax/templates'
+
   @exclude_paths = []
   @hieradata_paths = [
     "**/data/**/*.*{yaml,yml}",

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -3,6 +3,7 @@ module PuppetSyntax
     def check(filelist)
       raise "Expected an array of files" unless filelist.is_a?(Array)
       require 'puppet'
+      require 'puppet/version'
       require 'puppet/face'
       require 'puppet/test/test_helper'
 

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -1,5 +1,4 @@
 require 'erb'
-require 'puppet'
 require 'stringio'
 
 module PuppetSyntax
@@ -30,6 +29,7 @@ module PuppetSyntax
     end
 
     def validate_epp(filename)
+      require 'puppet/error'
       require 'puppet/pops'
       result = { warnings: [], errors: [] }
       formatter = Puppet::Pops::Validation::DiagnosticFormatterPuppetStyle.new


### PR DESCRIPTION
This allows requiring puppet-syntax without loading all of Puppet, which helps speed up other rake commands.