### PR TITLE
support aliases in hiera yaml

### DIFF
--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -74,7 +74,8 @@ module PuppetSyntax
 
       filelist.each do |hiera_file|
         begin
-          yamldata = YAML.load_file(hiera_file, aliases: true)
+          yamlargs = RUBY_VERSION >= '3.1' ? { aliases: true } : {}
+          yamldata = YAML.load_file(hiera_file, **yamlargs)
         rescue Exception => error
           errors << "ERROR: Failed to parse #{hiera_file}: #{error}"
           next

--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -72,9 +72,10 @@ module PuppetSyntax
 
       errors = []
 
+      yamlargs = Psych::VERSION >= '4.0' ? { aliases: true } : {}
+
       filelist.each do |hiera_file|
         begin
-          yamlargs = RUBY_VERSION >= '3.1' ? { aliases: true } : {}
           yamldata = YAML.load_file(hiera_file, **yamlargs)
         rescue Exception => error
           errors << "ERROR: Failed to parse #{hiera_file}: #{error}"

--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -74,7 +74,7 @@ module PuppetSyntax
 
       filelist.each do |hiera_file|
         begin
-          yamldata = YAML.load_file(hiera_file)
+          yamldata = YAML.load_file(hiera_file, aliases: true)
         rescue Exception => error
           errors << "ERROR: Failed to parse #{hiera_file}: #{error}"
           next


### PR DESCRIPTION
This enables support for Hiera YAML files that contain aliases. As an example, with the current version I see this error:

```
❯ bundle exec rake syntax
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
ERROR: Failed to parse data/mac/2c:4d:54:4f:be:c3.yaml: Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.
```

This is the file it's referring to: https://github.com/halyard/halyard/blob/main/data/mac/2c%3A4d%3A54%3A4f%3Abe%3Ac3.yaml#L43

This PR adds the aliases: true flag, which seems right to me given that Puppet/Hiera allow aliases when parsing YAML.