### PR TITLE
fix "NameError: uninitialized constant Puppet::Util" 

### DIFF
--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -29,8 +29,7 @@ module PuppetSyntax
     end
 
     def validate_epp(filename)
-      require 'puppet/error'
-      require 'puppet/pops'
+      require 'puppet'
       result = { warnings: [], errors: [] }
       formatter = Puppet::Pops::Validation::DiagnosticFormatterPuppetStyle.new
       evaluating_parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new


### PR DESCRIPTION
when running syntax:templates on its own, not everything required was apparently loaded