### PR TITLE
Enable Hiera syntax check

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -19,8 +19,8 @@ module PuppetSyntax
     '**/templates/**/*.epp',
   ]
   @fail_on_deprecation_notices = true
-  @check_hiera_keys = false
-  @check_hiera_data = false
+  @check_hiera_keys = true
+  @check_hiera_data = true
 
   class << self
     attr_accessor :exclude_paths,


### PR DESCRIPTION
The check exists since a long time and I think it makes sense to enable it by default. This is a potential breaking change, so we should probably wait with merging until the next major release.