### PR TITLE
fix too greedy regular expression

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,7 +86,7 @@ RSpec/DescribedClass:
 # Offense count: 7
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
-  Max: 16
+  Max: 17
 
 # Offense count: 4
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
@@ -100,7 +100,7 @@ RSpec/FilePath:
 
 # Offense count: 29
 RSpec/MultipleExpectations:
-  Max: 10
+  Max: 11
 
 # Offense count: 30
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.

--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -122,7 +122,7 @@ module PuppetSyntax
     # You can do string concatenation outside of {}:
     # "%{lookup('this_is_ok')}:3306"
     def check_broken_function_call(element)
-      'string after a function call but before `}` in the value' if element.is_a?(String) && /%{.+\('.*'\).+}/.match?(element)
+      'string after a function call but before `}` in the value' if element.is_a?(String) && /%{[^}]+\('[^}]*'\)[^}\s]+}/.match?(element)
     end
 
     # gets a hash or array, returns all keys + values as array

--- a/spec/fixtures/hiera/hiera_badkey.yaml
+++ b/spec/fixtures/hiera/hiera_badkey.yaml
@@ -3,6 +3,7 @@ this_is_ok: 0
 this_is_ok::too: 0
 th1s_is_ok::two3: 0
 :eventhis: 0
+this_is_ok::concat_func: "%{lookup('foo')}%{lookup('bar')}"
 
 typical:typo::warning1:   true
 ::notsotypical::warning2: true
@@ -15,3 +16,4 @@ this_is::warning7:
   - "%{lookup('foobar'):3306}"
 this_is::warning8:
   foo: "%{lookup('foobar'):3306}"
+this_is::warning9: "%{lookup('foo'):3306}%{lookup('bar')}"

--- a/spec/puppet-syntax/hiera_spec.rb
+++ b/spec/puppet-syntax/hiera_spec.rb
@@ -29,7 +29,7 @@ describe PuppetSyntax::Hiera do
 
     it 'returns warnings for invalid keys' do
       hiera_yaml = 'hiera_badkey.yaml'
-      examples = 8
+      examples = 9
       files = fixture_hiera(hiera_yaml)
       res = subject.check(files)
       (1..examples).each do |n|
@@ -44,6 +44,7 @@ describe PuppetSyntax::Hiera do
       expect(res[5]).to match('Key :this_is::warning6: string after a function call but before `}` in the value')
       expect(res[6]).to match('Key :this_is::warning7: string after a function call but before `}` in the value')
       expect(res[7]).to match('Key :this_is::warning8: string after a function call but before `}` in the value')
+      expect(res[8]).to match('Key :this_is::warning9: string after a function call but before `}` in the value')
     end
 
     it 'returns warnings for bad eyaml values' do


### PR DESCRIPTION
This PR fixes a too greedy regular expression for `rake syntax:hiera`.

Description:
Given these keys in a common.yaml:
```yaml
---
firstkey: 'one'
secondkey: 'two'
mymod::mykey: "%{lookup('firstkey')}%{lookup('secondkey')}"
```

This concatenates the keys 'firstkey' ('one') and 'secondkey' ('two') to 'mykey' ('onetwo').
Because of a too greedy regular expression, this leads to a warning, which shouldn't.

Expected result:
```text
# rake syntax:hiera
---> syntax:hiera:yaml
#
```

Actual result:
```text
# rake syntax:hiera
---> syntax:hiera:yaml
WARNING: data/common.yaml: Key :mymod::mykey: string after a function call but before `}` in the value
#
```

Explanation:
The regular expression `/%{.+\('.*'\).+}/` matches `%{lookup('firstkey')}%{lookup('secondkey')}`, which fires the Warning.
The regular expression `/%{[^}]+\('[^}]*'\)[^}\s]+}/` does not match `%{lookup('firstkey')}%{lookup('secondkey')}`.
It still matches `%{lookup('firstkey'):3306}%{lookup('secondkey')}` or any other non-whitespace character between `)` and the next `}` in a function interpolation, which is the purpose of the Warning.