### PR TITLE
Detect Hiera files that are not valid hashes

### DIFF
--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -92,6 +92,11 @@ module PuppetSyntax
         end
         next unless yamldata
 
+        unless yamldata.is_a?(Hash)
+          errors << "ERROR: #{hiera_file} doesn't contain a valid Hash, datatype is #{yamldata.class}"
+          next
+        end
+
         yamldata.each do |k, v|
           if PuppetSyntax.check_hiera_keys
             key_msg = check_hiera_key(k)

--- a/spec/fixtures/hiera/hiera_key_no_value.yaml
+++ b/spec/fixtures/hiera/hiera_key_no_value.yaml
@@ -1,0 +1,2 @@
+prometheus::initstyle:sysv
+prometheus::node_exporter::init_style:sysv

--- a/spec/puppet-syntax/hiera_spec.rb
+++ b/spec/puppet-syntax/hiera_spec.rb
@@ -21,6 +21,14 @@ describe PuppetSyntax::Hiera do
     expect(res.first).to match(expected)
   end
 
+  it 'returns warnings on malformed keys' do
+    files = fixture_hiera('hiera_key_no_value.yaml')
+    expected = /ERROR: #{files[0]} doesn't contain a valid Hash, datatype is/
+    res = subject.check(files)
+    expect(res.size).to eq 1
+    expect(res.first).to match(expected)
+  end
+
   context 'check_hiera_keys = true' do
     before do
       PuppetSyntax.check_hiera_keys = true


### PR DESCRIPTION
This was reported on slack via @ikonia. with such malformed keys, Hiera just reports a string:

```
irb(main):002> require 'yaml'
=> true
irb(main):003> yamlargs = (Psych::VERSION >= '4.0') ? { aliases: true } : {}
=> {aliases: true}
irb(main):004> hiera_file='spec/fixtures/hiera/hiera_key_no_value.yaml'
=> "spec/fixtures/hiera/hiera_key_no_value.yaml"
irb(main):005> YAML.load_file(hiera_file, **yamlargs)
=> "prometheus::initstyle:sysv prometheus::node_exporter::init_style:sysv"
irb(main):006>
```

And puppetserver will fail to compile a catalog:

```
Notice: Catalog compiled by ***
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, /etc/puppetlabs/code/environments/***.yaml: file does not contain a valid yaml hash on node ***
Warning: Not using cache on failed catalog
```