### PR TITLE
Update Hiera key regex to Puppet supported values

### DIFF
--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -12,7 +12,7 @@ module PuppetSyntax
         elsif !/^[a-z]+$/.match?(key) # we allow Hiera's own configuration
           'Puppet automatic lookup will not look up symbols'
         end
-      elsif !/^[a-z][a-z0-9_]+(::[a-z][a-z0-9_]+)*$/.match?(key)
+      elsif !/^([a-z][a-z0-9_]+::)*[a-z0-9_][a-zA-Z0-9_]+$/.match?(key) # adapted from Puppet docs combining namespaced and un-namespace regex
         return 'Looks like a missing colon' if /[^:]:[^:]/.match?(key)
 
         # be extra helpful

--- a/lib/puppet-syntax/hiera.rb
+++ b/lib/puppet-syntax/hiera.rb
@@ -12,7 +12,7 @@ module PuppetSyntax
         elsif !/^[a-z]+$/.match?(key) # we allow Hiera's own configuration
           'Puppet automatic lookup will not look up symbols'
         end
-      elsif !/^([a-z][a-z0-9_]+::)*[a-z0-9_][a-zA-Z0-9_]+$/.match?(key) # adapted from Puppet docs combining namespaced and un-namespace regex
+      elsif !/^([a-z][a-z0-9_]+::)*[a-z0-9_][a-zA-Z0-9_]+$/.match?(key) # adapted from Puppet docs combining namespaced and un-namespaced regex
         return 'Looks like a missing colon' if /[^:]:[^:]/.match?(key)
 
         # be extra helpful


### PR DESCRIPTION
This pull request updates the regular expression for Hiera keys to follow the [latest Puppet 8 documentation on variable names](https://help.puppet.com/core/8/Content/PuppetCore/lang_acceptable_char.htm). This regular expression is also consistent with [the Puppet 7 documentation on variable names](https://www.puppet.com/docs/puppet/7/lang_variables.html#variable-names).

To avoid complexity and allow for some niche cases where Hiera can contain non-namespaced variable names (for use in lookup functions), I combined the 2 regular expressions found in the documentation.

I have not been able to perform any integration testing as I don't have a great environment setup that will allow for that.  However, I was able to test this using regex101 with great success

<img width="969" height="600" alt="image" src="https://github.com/user-attachments/assets/043ee628-4fd0-4bb7-b22d-8a54addae600" />

Closes #193 