### PR TITLE
feature: add support for multiple encoded blocks

### DIFF
--- a/spec/fixtures/hiera/hiera_bad.eyaml
+++ b/spec/fixtures/hiera/hiera_bad.eyaml
@@ -1,11 +1,11 @@
 ---
-acme::warning1: ENC[unknown-method,aGVsbG8sIHdvcmxk]
-acme::warning2: ENC[PKCS7,aGVsbG8sIHdvcmxk
-acme::warning3: ENC[PKCS7,aGVsbG8sIHdvcmxk==]
-acme::warning4: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk]
+acme::warning1: ENC[unknown-method,aGVsbG8sIHdvcmxk] # unknown method
+acme::warning2: ENC[PKCS7,aGVsbG8sIHdvcmxk # has unterminated eyaml value
+acme::warning3: ENC[PKCS7,aGVsbG8sIHdvcmxk==] # unpadded or truncated base64 data
+acme::warning4: ENC[PKCS7,aGVsbG8sf&IHdvcmxk==] # corrupt base64 data
 acme::warning5:
   key1: foo
-  key2: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk]
+  key2: ENC[PKCS7,aGVs!!!!bG8sIHdvcmxk] # corrupt base64 data
 acme::warning6:
   hash_key:
     - element1
@@ -17,8 +17,9 @@ acme::warning6:
       ENC[PKCS7,
           aGVs!!!!bG8sIHdvcmxk
       ]
-acme::good1: >
-   ENC[PKCS7,
-     aGVsbG8sIHdvcmxk]
-acme::good2: ENC[GPG,aGVsbG8sIHdvcmxkIQ==]
-acme::good3: ENC[GPG,aGVsbG8sIHdvcmxkISE=]
+    # corrupt base64 data
+acme::warning7: ENC[] # has invalid eyaml encoded format
+acme::warning8: ENC[PKCS7,aGV&&&sbG8sIHdvcmxk] # unpadded or truncated base64 data
+acme::warning9: | # has unterminated eyaml value
+  ENC[aGVsbG8sIHdvcmxk
+  ENC[aGVsbG8sIHdvcmxk]

--- a/spec/fixtures/hiera/hiera_good.eyaml
+++ b/spec/fixtures/hiera/hiera_good.eyaml
@@ -1,0 +1,13 @@
+---
+acme::good1: ENC[KMS,aGVsbG8sIdGHdvcmxk==]
+acme::good2: ENC[PKCS7,aGVsbG8sf3IHdvcmxk==]
+acme::good3: ENC[KMS,aGVsbG8sIdGHdvcmxk==]ENC[KMS,aGVsbG8sIdGHdvcmxk==]
+acme::good4: >
+   ENC[PKCS7,
+     aGVsbG8sIHdvcmxk]
+acme::good5: ENC[GPG,aGVsbG8sIHdvcmxkIQ==]
+acme::good6: ENC[GPG,aGVsbG8sIHdvcmxkISE=]
+acme::good7: |
+    text
+    ENC[GPG,aGVsbG8sIHdvcmxkISE=]
+acme::good8: ENC[aGVsbG8sf3IHdvcmxk==]

--- a/spec/puppet-syntax/hiera_spec.rb
+++ b/spec/puppet-syntax/hiera_spec.rb
@@ -71,9 +71,15 @@ describe PuppetSyntax::Hiera do
       expect(res[2]).to match('Key :this_is::warning3: string after a function call but before `}` in the value')
     end
 
+    it 'returns nothing for good eyaml' do
+      files = fixture_hiera('hiera_good.eyaml')
+      res = subject.check(files)
+      expect(res).to eq []
+    end
+
     it 'returns warnings for bad eyaml values' do
       hiera_yaml = 'hiera_bad.eyaml'
-      examples = 6
+      examples = 9
       files = fixture_hiera(hiera_yaml)
       res = subject.check(files)
       (1..examples).each do |n|
@@ -86,6 +92,9 @@ describe PuppetSyntax::Hiera do
       expect(res[3]).to match('Key acme::warning4 has corrupt base64 data')
       expect(res[4]).to match('Key acme::warning5\[\'key2\'\] has corrupt base64 data')
       expect(res[5]).to match('Key acme::warning6\[\'hash_key\'\]\[2\] has corrupt base64 data')
+      expect(res[6]).to match('Key acme::warning7 has invalid eyaml encoded format')
+      expect(res[7]).to match('Key acme::warning8 has unpadded or truncated base64 data')
+      expect(res[8]).to match('Key acme::warning9 has unterminated eyaml value')
     end
 
     it 'handles empty files' do


### PR DESCRIPTION
inspired by #127
fixes #210 

hiera-eyaml supports multiple encoded strings in one value. It also supports text + encoded strings in one value.

puppet-syntax does not support it currently.

To fix this i added some more tests and refactored the search for encoded strings to support multiple encoded strings.